### PR TITLE
Standard einode memory leaks

### DIFF
--- a/oasis/DataChannel/Data_Channel.inl
+++ b/oasis/DataChannel/Data_Channel.inl
@@ -20,7 +20,7 @@ Data_Channel::Data_Channel (void)
 OASIS_INLINE
 Data_Channel::~Data_Channel (void)
 {
-
+  delete packager_;
 }
 
 //

--- a/oasis/probes/Software_Probe_Impl.h
+++ b/oasis/probes/Software_Probe_Impl.h
@@ -31,10 +31,10 @@ protected:
   /// Default constructor.
   Software_Probe_Impl (void);
 
+public:
   /// Destructor.
   virtual ~Software_Probe_Impl (void);
 
-public:
   /// Get the software probe's instance name.
   const ACE_CString & instance_name (void) const;
 


### PR DESCRIPTION
Running valgrind with  OASIS/tests/EINode/Smoke_Test/OASIS_Einode_Smoke_Test shows a number of memory leaks:
Standard_EINode.cpp:163 the management of the Software_Probe_Impl Map and dtor visibility
Standard_EINode.cpp:305 packager prototype and clone management in Data_Channel
Standard_EINode.cpp:157 factory memory management
