### PR TITLE
removed const-ness from dump method on based Software_Probe and Softw…

### DIFF
--- a/oasis/probes/Software_Probe.h
+++ b/oasis/probes/Software_Probe.h
@@ -62,7 +62,7 @@ public:
                       int byte_order);
 
   /// Dump the contents of the probe to ACE_DEUBG
-  virtual void dump (std::ostream & output) const;
+  virtual void dump (std::ostream & output);
 
   /// Get the software probe's UUID
   const ACE_Utils::UUID & uuid (void) const;

--- a/oasis/probes/Software_Probe_Impl.h
+++ b/oasis/probes/Software_Probe_Impl.h
@@ -54,7 +54,7 @@ public:
   const ACE_UINT32 & data_size (void) const;
 
   /// Dump the contents of the probe to ACE_DEUBG
-  virtual void dump (std::ostream & output) const;
+  virtual void dump (std::ostream & output);
 
   /// Get the software probe's metadata.
   virtual const Software_Probe_Metadata & metadata (void) const = 0;


### PR DESCRIPTION
OASIS/OASIS_PDL/be/cpp/Impl_Dump_Generator.cpp  
OASIS/OASIS_PDL/be/cpp/Stub_Dump_Generator.cpp 
both generate output

virtual void dump(std::ostream &); 

which are inconsistent with the base class definitions in Software_Probe.h and Software_Probe_Impl.h which are 'const' and although I agree with the const-ness qualify on the base classes modifying the generators leads to an explosion of problems. 
